### PR TITLE
feat: Regolith project integration (v1.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <div align="center">
 
 [![GitHub Stars](https://img.shields.io/github/stars/keyyard/create-mc-bedrock-cli?style=social)](https://github.com/keyyard/create-mc-bedrock-cli)
-[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/keyyard/create-mc-bedrock-cli)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue.svg)](https://github.com/keyyard/create-mc-bedrock-cli)
 [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green.svg)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE)
 
@@ -29,6 +29,7 @@ With `create-mc-bedrock`, you can bootstrap your next project in seconds, using 
 ## Table of Contents
 - [✨ Why Use Create MC Bedrock CLI?](#-why-use-create-mc-bedrock-cli)
 - [🚀 How It Works](#-how-it-works)
+- [🔧 Regolith Integration](#-regolith-integration)
 - [📸 Showcase](#-showcase)
 - [🛠️ Features](#-features)
 - [📦 Requirements](#-requirements)
@@ -71,6 +72,37 @@ Choose from a curated list of Microsoft’s best scripting samples. Your selecte
 
 ---
 
+## 🔧 Regolith Integration
+
+[Regolith](https://github.com/Bedrock-OSS/regolith) is a popular Bedrock addon compiler that runs filter pipelines on your BP/RP before exporting to `com.mojang`. Create MC Bedrock CLI now supports scaffolding Regolith-compatible projects out of the box.
+
+When the CLI asks **"Set up as a Regolith project?"**, answering yes will:
+
+- Flatten the pack folders from `behavior_packs/<name>/` → `BP/` and `resource_packs/<name>/` → `RP/` (the layout Regolith expects)
+- Generate a `config.json` with the correct Regolith schema (name, author, packs, profiles, filterDefinitions)
+- Create a `data/` directory for filter data
+- Create a `.regolith/` directory (Regolith's internal cache)
+- Add `/build` and `/.regolith` to `.gitignore`
+
+**Resulting structure:**
+```
+my-addon/
+  config.json       ← Regolith config
+  BP/               ← behavior pack source
+  RP/               ← resource pack source
+  data/             ← filter data
+  .regolith/        ← Regolith cache (git-ignored)
+  .gitignore
+```
+
+**Next steps after scaffolding with Regolith:**
+1. [Install Regolith](https://regolith-docs.readthedocs.io/en/latest/introduction/installation/)
+2. Add filters to `config.json` under `regolith.filterDefinitions`
+3. Run `regolith install-all` to download filter dependencies
+4. Run `regolith run` to compile your addon
+
+---
+
 ## 📸 Showcase
 
 <div align="center">
@@ -87,6 +119,7 @@ Choose from a curated list of Microsoft’s best scripting samples. Your selecte
 - Direct cloning to your specified folder (no more nested directories)
 - Automatic manifest UUID regeneration for every project
 - Supports both JavaScript and TypeScript samples
+- **Regolith integration** — optional one-prompt scaffold for Regolith-compatible projects (flat `BP/`/`RP/`, `config.json`, `data/`)
 - Cleans up temporary files after setup
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mc-bedrock",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "create-mc-bedrock is a simple and interactive CLI tool to help you quickly set up Minecraft Bedrock workspaces with given templates from both Microsoft's and Customs!",
   "main": "src/cli/index.js",
   "bin": {

--- a/src/cli/commands.js
+++ b/src/cli/commands.js
@@ -1,5 +1,32 @@
 import inquirer from 'inquirer';
 import { getSourceOptions, getCustomCategories, getCustomTemplates } from '../services/gitService.js';
+
+// Prompt asking whether the user wants a Regolith-compatible project
+export async function promptRegolith() {
+  const { useRegolith } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'useRegolith',
+      message: 'Set up as a Regolith project? (adds config.json, BP/, RP/, data/ structure)',
+      default: false
+    }
+  ]);
+
+  let author = 'Unknown';
+  if (useRegolith) {
+    const { authorInput } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'authorInput',
+        message: 'Author name for config.json:',
+        default: 'Unknown'
+      }
+    ]);
+    author = authorInput;
+  }
+
+  return { useRegolith, author };
+}
 // Prompt for category if custom source is selected
 export async function promptCategory() {
   let categories = await getCustomCategories();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { displayAsciiArt } from '../utils/logger.js';
 import { fetchSamples, getSamples } from '../services/gitService.js';
-import { promptSource, promptUser, promptCategory, promptTemplate } from './commands.js';
+import { promptSource, promptUser, promptCategory, promptTemplate, promptRegolith } from './commands.js';
 import { moveSample } from '../services/fileService.js';
 import { updateManifestFiles } from '../services/manifestService.js';
+import { applyRegolithStructure } from '../services/regolithService.js';
 import { cleanupTempFiles } from '../utils/helpers.js';
 import path from 'path';
 import inquirer from 'inquirer';
@@ -51,11 +52,21 @@ async function run() {
     }
 
     const targetPath = path.resolve(destination);
+
+    // Ask about Regolith before doing anything — keeps prompts together
+    const { useRegolith, author } = await promptRegolith();
+
     await moveSample(samplePath, targetPath);
 
     // Update manifest files after moving the sample
     const relativePath = path.relative(process.cwd(), targetPath);
     await updateManifestFiles(relativePath, destination);
+
+    // Optionally restructure as a Regolith project
+    if (useRegolith) {
+      const projectName = path.basename(targetPath);
+      await applyRegolithStructure(targetPath, projectName, author);
+    }
 
   } catch (error) {
     console.error(error.message);

--- a/src/services/manifestService.js
+++ b/src/services/manifestService.js
@@ -5,8 +5,8 @@ import { v4 as uuidv4 } from 'uuid';
 export async function updateManifestFiles(destination, userInputName) {
   // Find manifest paths dynamically
   const manifestPaths = [];
-  
-  // Check for behavior_packs folder and find the first subfolder
+
+  // --- Standard structure: behavior_packs/<subfolder>/manifest.json ---
   const bpDir = path.join(destination, 'behavior_packs');
   try {
     const bpEntries = await fs.readdir(bpDir, { withFileTypes: true });
@@ -14,11 +14,11 @@ export async function updateManifestFiles(destination, userInputName) {
     if (bpFolder) {
       manifestPaths.push(path.join(bpDir, bpFolder.name, 'manifest.json'));
     }
-  } catch (error) {
+  } catch {
     // behavior_packs folder doesn't exist, skip
   }
 
-  // Check for resource_packs folder and find the first subfolder
+  // --- Standard structure: resource_packs/<subfolder>/manifest.json ---
   const rpDir = path.join(destination, 'resource_packs');
   try {
     const rpEntries = await fs.readdir(rpDir, { withFileTypes: true });
@@ -26,9 +26,21 @@ export async function updateManifestFiles(destination, userInputName) {
     if (rpFolder) {
       manifestPaths.push(path.join(rpDir, rpFolder.name, 'manifest.json'));
     }
-  } catch (error) {
+  } catch {
     // resource_packs folder doesn't exist, skip
   }
+
+  // --- Regolith structure: BP/manifest.json and RP/manifest.json ---
+  const flatBpManifest = path.join(destination, 'BP', 'manifest.json');
+  const flatRpManifest = path.join(destination, 'RP', 'manifest.json');
+  try {
+    await fs.access(flatBpManifest);
+    if (!manifestPaths.includes(flatBpManifest)) manifestPaths.push(flatBpManifest);
+  } catch { /* not present */ }
+  try {
+    await fs.access(flatRpManifest);
+    if (!manifestPaths.includes(flatRpManifest)) manifestPaths.push(flatRpManifest);
+  } catch { /* not present */ }
 
   // Generate UUIDs for BP and RP headers to maintain dependency relationship
   const bpHeaderUuid = uuidv4();
@@ -40,7 +52,9 @@ export async function updateManifestFiles(destination, userInputName) {
       if (!manifestExists) continue;
 
       const manifestContent = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
-      const isBehaviorPack = manifestPath.includes('behavior_packs');
+      // Works for both standard (behavior_packs/...) and Regolith (BP/) structures
+      const isBehaviorPack = manifestPath.includes('behavior_packs') ||
+        manifestPath.replace(/\\/g, '/').endsWith('/BP/manifest.json');
 
       // Update header UUID
       manifestContent.header.uuid = isBehaviorPack ? bpHeaderUuid : rpHeaderUuid;

--- a/src/services/regolithService.js
+++ b/src/services/regolithService.js
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Restructures a scaffolded Bedrock project to be Regolith-compatible.
+ *
+ * What it does:
+ *  1. Flattens behavior_packs/<name>/ → BP/
+ *  2. Flattens resource_packs/<name>/ → RP/
+ *  3. Writes config.json with the correct Regolith schema
+ *  4. Creates data/ and .regolith/ directories
+ *  5. Writes a .gitignore that excludes /build and /.regolith
+ *
+ * @param {string} destination  Absolute path to the project root
+ * @param {string} projectName  The name the user gave the project
+ * @param {string} author       Author name (defaults to 'Unknown')
+ */
+export async function applyRegolithStructure(destination, projectName, author = 'Unknown') {
+  // 1. Flatten behavior_packs/<subfolder>/ → BP/
+  await flattenPackFolder(destination, 'behavior_packs', 'BP');
+
+  // 2. Flatten resource_packs/<subfolder>/ → RP/
+  await flattenPackFolder(destination, 'resource_packs', 'RP');
+
+  // 3. Create data/ directory (Regolith filter data lives here)
+  await fs.mkdir(path.join(destination, 'data'), { recursive: true });
+
+  // 4. Create .regolith/ directory (Regolith cache, git-ignored)
+  await fs.mkdir(path.join(destination, '.regolith'), { recursive: true });
+
+  // 5. Write config.json
+  const config = buildRegolithConfig(projectName, author);
+  await fs.writeFile(
+    path.join(destination, 'config.json'),
+    JSON.stringify(config, null, 2),
+    'utf-8'
+  );
+
+  // 6. Write .gitignore (Regolith standard)
+  const gitignorePath = path.join(destination, '.gitignore');
+  let existing = '';
+  try {
+    existing = await fs.readFile(gitignorePath, 'utf-8');
+  } catch {
+    // file doesn't exist yet — that's fine
+  }
+  const regolithIgnore = '/build\n/.regolith\n';
+  if (!existing.includes('/.regolith')) {
+    await fs.writeFile(gitignorePath, existing + regolithIgnore, 'utf-8');
+  }
+
+  console.log('✅ Regolith project structure applied!');
+  console.log('   • BP/         ← your behavior pack source');
+  console.log('   • RP/         ← your resource pack source');
+  console.log('   • data/       ← filter data folder');
+  console.log('   • config.json ← Regolith configuration');
+  console.log('   ℹ  Run `regolith init` is NOT needed — config.json is already generated.');
+  console.log('   ℹ  Add filters to config.json → regolith.filterDefinitions, then run `regolith install-all`.');
+}
+
+/**
+ * Moves the first subfolder of `behavior_packs/` or `resource_packs/`
+ * to a flat `BP/` or `RP/` at the project root, then removes the now-empty
+ * nested directory.
+ */
+async function flattenPackFolder(destination, nestedDir, flatDir) {
+  const nestedPath = path.join(destination, nestedDir);
+  const flatPath = path.join(destination, flatDir);
+
+  try {
+    const entries = await fs.readdir(nestedPath, { withFileTypes: true });
+    const subfolder = entries.find(e => e.isDirectory());
+
+    if (subfolder) {
+      const subfolderPath = path.join(nestedPath, subfolder.name);
+      // Move subfolder contents to flatDir
+      await moveDirectory(subfolderPath, flatPath);
+      // Remove the now-empty nested pack folder
+      await fs.rm(nestedPath, { recursive: true, force: true });
+    } else {
+      // No subfolder found — just rename the root pack dir
+      await fs.rename(nestedPath, flatPath);
+    }
+  } catch (err) {
+    // nestedDir doesn't exist (template may not have one), create empty flatDir
+    console.warn(`  ⚠ ${nestedDir} not found — creating empty ${flatDir}/`);
+    await fs.mkdir(flatPath, { recursive: true });
+  }
+}
+
+/**
+ * Recursively moves all contents of src into dest.
+ */
+async function moveDirectory(src, dest) {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await moveDirectory(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+/**
+ * Builds the Regolith config.json object.
+ * Matches the schema from regolith/regolith/config.go.
+ */
+function buildRegolithConfig(projectName, author) {
+  return {
+    name: projectName,
+    author: author,
+    packs: {
+      behaviorPack: './BP',
+      resourcePack: './RP'
+    },
+    regolith: {
+      formatVersion: '1.4.0',
+      dataPath: './data',
+      profiles: {
+        default: {
+          export: {
+            target: 'development'
+          },
+          filters: []
+        }
+      },
+      filterDefinitions: {}
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Adds optional [Regolith](https://github.com/Bedrock-OSS/regolith) compatibility to the scaffold flow. When the user answers **yes** to the new prompt, the CLI restructures the generated project to match Regolith's expected layout.

## What changed

### New: `src/services/regolithService.js`
- Flattens `behavior_packs/<name>/` → `BP/` and `resource_packs/<name>/` → `RP/` (Regolith's required flat structure)
- Writes `config.json` with correct Regolith schema (`name`, `author`, `packs`, `regolith.profiles`, `regolith.filterDefinitions`, `formatVersion`)
- Creates `data/` directory (filter data folder)
- Creates `.regolith/` directory (Regolith cache)
- Appends `/build` and `/.regolith` to `.gitignore`

### Updated: `src/cli/commands.js`
- Added `promptRegolith()`: asks yes/no for Regolith setup, and if yes, asks for author name

### Updated: `src/cli/index.js`
- Imports `promptRegolith` and `applyRegolithStructure`
- Calls `applyRegolithStructure()` after manifest update when Regolith mode is selected

### Updated: `src/services/manifestService.js`
- Added fallback detection for flat `BP/manifest.json` / `RP/manifest.json` (Regolith structure)
- Fixed bare `catch` blocks for cleaner ES2019+ compatibility

### Updated: `README.md` + `package.json`
- New **Regolith Integration** section with resulting folder structure and next steps
- Regolith feature added to Features list
- Version bumped to **1.5.0**

## Resulting project structure (Regolith mode)

```
my-addon/
  config.json       ← Regolith config (name, author, packs, profiles)
  BP/               ← behavior pack source
  RP/               ← resource pack source
  data/             ← filter data folder
  .regolith/        ← Regolith cache (git-ignored)
  .gitignore        ← /build and /.regolith entries added
```

## Backward compatibility

The Regolith prompt defaults to **No** — existing users who don't want Regolith get the same output as before. No breaking changes.